### PR TITLE
Unlink dummy data file on subsequent phpunit runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,12 +2,10 @@
 
 # Composer files
 vendor/
-composer.lock
 
 # Testing data
 tests/Coverage/
-tests/DummyData/GET_lol-test-endpoint-v0-save.json
-/tests/RiotAPI/Definition/cache-fcp/ 
+tests/RiotAPI/Definition/cache-fcp/
 
 # Cache
 src/RiotAPI/cache/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,13 @@
 .idea/
+
+# Composer files
 vendor/
+composer.lock
+
+# Testing data
 tests/Coverage/
 tests/DummyData/GET_lol-test-endpoint-v0-save.json
+/tests/RiotAPI/Definition/cache-fcp/ 
+
+# Cache
 src/RiotAPI/cache/
-composer.lock

--- a/tests/RiotAPI/Library/LibraryTest.php
+++ b/tests/RiotAPI/Library/LibraryTest.php
@@ -468,14 +468,13 @@ class LibraryTest extends RiotAPITestCase
 		}
 		catch (RequestException $ex) {}
 
-		// Removes the dummy data file on subsequent runs
-		if (\file_exists($api->_getDummyDataFileName())) {
-			unlink($api->_getDummyDataFileName());
-		}
-
 		$this->assertFileNotExists($api->_getDummyDataFileName());
 		$api->_saveDummyData();
 		$this->assertFileExists($api->_getDummyDataFileName(), "DummyData file was not created correctly.");
+
+		// Removes the dummy data file on subsequent runs
+		if (\file_exists($api->_getDummyDataFileName()))
+			unlink($api->_getDummyDataFileName());
 	}
 
 	/**

--- a/tests/RiotAPI/Library/LibraryTest.php
+++ b/tests/RiotAPI/Library/LibraryTest.php
@@ -468,6 +468,11 @@ class LibraryTest extends RiotAPITestCase
 		}
 		catch (RequestException $ex) {}
 
+		// Removes the dummy data file on subsequent runs
+		if (\file_exists($api->_getDummyDataFileName())) {
+			unlink($api->_getDummyDataFileName());
+		}
+
 		$this->assertFileNotExists($api->_getDummyDataFileName());
 		$api->_saveDummyData();
 		$this->assertFileExists($api->_getDummyDataFileName(), "DummyData file was not created correctly.");

--- a/tests/RiotAPI/Library/LibraryTest.php
+++ b/tests/RiotAPI/Library/LibraryTest.php
@@ -473,7 +473,7 @@ class LibraryTest extends RiotAPITestCase
 		$this->assertFileExists($api->_getDummyDataFileName(), "DummyData file was not created correctly.");
 
 		// Removes the dummy data file on subsequent runs
-		if (\file_exists($api->_getDummyDataFileName()))
+		if (file_exists($api->_getDummyDataFileName()))
 			unlink($api->_getDummyDataFileName());
 	}
 


### PR DESCRIPTION
Hi, apologies in advance if I skipped any part of the contribution process - I think this is my first PR to anything with actual code it in.

I noticed that the dummy data file wasn't cleaned up after running this PHPUnit test, leading to a failure on subsequent runs, so I just had the test case delete the file before doing it's thing.

I also made the .gitignore a bit prettier and more descriptive.