### PR TITLE
Changed capitalization of DTO to Dto

### DIFF
--- a/src/RiotAPI/Objects/LeagueItemDto.php
+++ b/src/RiotAPI/Objects/LeagueItemDto.php
@@ -39,7 +39,7 @@ class LeagueItemDto extends ApiObject
 	/** @var bool $hotStreak */
 	public $hotStreak;
 
-	/** @var MiniSeriesDTO $miniSeries */
+	/** @var MiniSeriesDto $miniSeries */
 	public $miniSeries;
 
 	/** @var int $wins */

--- a/src/RiotAPI/Objects/LeagueListDto.php
+++ b/src/RiotAPI/Objects/LeagueListDto.php
@@ -41,7 +41,7 @@ class LeagueListDto extends ApiObjectIterable
 	/** @var string $tier */
 	public $tier;
 
-	/** @var LeagueItemDTO[] $entries */
+	/** @var LeagueItemDto[] $entries */
 	public $entries;
 
 	/** @var string $queue */

--- a/src/RiotAPI/Objects/LeaguePositionDto.php
+++ b/src/RiotAPI/Objects/LeaguePositionDto.php
@@ -40,7 +40,7 @@ class LeaguePositionDto extends ApiObject
 	/** @var bool $hotStreak */
 	public $hotStreak;
 
-	/** @var MiniSeriesDTO $miniSeries */
+	/** @var MiniSeriesDto $miniSeries */
 	public $miniSeries;
 
 	/** @var int $wins */

--- a/src/RiotAPI/Objects/LobbyEventDtoWrapper.php
+++ b/src/RiotAPI/Objects/LobbyEventDtoWrapper.php
@@ -33,6 +33,6 @@ namespace RiotAPI\Objects;
  */
 class LobbyEventDtoWrapper extends ApiObjectIterable
 {
-	/** @var LobbyEventDTO[] $eventList */
+	/** @var LobbyEventDto[] $eventList */
 	public $eventList;
 }

--- a/src/RiotAPI/RiotAPI.php
+++ b/src/RiotAPI/RiotAPI.php
@@ -2225,7 +2225,7 @@ class RiotAPI
 	 * @param string                                 $tournament_code
 	 * @param Objects\TournamentCodeUpdateParameters $parameters
 	 *
-	 * @return Objects\LobbyEventDTOWrapper
+	 * @return Objects\LobbyEventDtoWrapper
 	 *
 	 * @throws SettingsException
 	 * @throws RequestException


### PR DESCRIPTION
On Windows, an exception is thrown because it can't find the "MiniSeriesDTO" object. 
My guess is that is because the Windows file system is case-sensitive.
