### PR TITLE
Use new method to receive league entries. Fixes #52

### DIFF
--- a/src/LeagueAPI/LeagueAPI.php
+++ b/src/LeagueAPI/LeagueAPI.php
@@ -1556,8 +1556,8 @@ class LeagueAPI
 	 */
 	public function getLeaguePositionsForSummoner( string $encrypted_summoner_id )
 	{
-		$resultPromise = $this->setEndpoint("/lol/league/" . self::RESOURCE_LEAGUE_VERSION . "/positions/by-summoner/{$encrypted_summoner_id}")
-			->setResource(self::RESOURCE_LEAGUE, "/positions/by-summoner/%s")
+		$resultPromise = $this->setEndpoint("/lol/league/" . self::RESOURCE_LEAGUE_VERSION . "/entries/by-summoner/{$encrypted_summoner_id}")
+			->setResource(self::RESOURCE_LEAGUE, "/entries/by-summoner/%s")
 			->makeCall();
 
 		return $this->resolveOrEnqueuePromise($resultPromise, function(array $result) {


### PR DESCRIPTION
Riot deprecated the old method and replaced it: https://www.riotgames.com/en/DevRel/riot-api-update-190417.

This pull request reflects these changes.