### PR TITLE
Throw error in case summoner name is empty

### DIFF
--- a/src/LeagueAPI/LeagueAPI.php
+++ b/src/LeagueAPI/LeagueAPI.php
@@ -2646,8 +2646,8 @@ class LeagueAPI
 	{
 		$summoner_name = str_replace(' ', '', $summoner_name);
 		if (trim($summoner_name) === '') {
-		    throw new RequestParameterException('Provided summoner name must not be empty');
-        }
+			throw new RequestParameterException('Provided summoner name must not be empty');
+		}
 
 		$resultPromise = $this->setEndpoint("/lol/summoner/" . self::RESOURCE_SUMMONER_VERSION . "/summoners/by-name/{$summoner_name}")
 			->setResource(self::RESOURCE_SUMMONER, "/summoners/by-name/%s")

--- a/src/LeagueAPI/LeagueAPI.php
+++ b/src/LeagueAPI/LeagueAPI.php
@@ -2645,6 +2645,9 @@ class LeagueAPI
 	public function getSummonerByName( string $summoner_name )
 	{
 		$summoner_name = str_replace(' ', '', $summoner_name);
+		if (trim($summoner_name) === '') {
+		    throw new RequestParameterException('Provided summoner name must not be empty');
+        }
 
 		$resultPromise = $this->setEndpoint("/lol/summoner/" . self::RESOURCE_SUMMONER_VERSION . "/summoners/by-name/{$summoner_name}")
 			->setResource(self::RESOURCE_SUMMONER, "/summoners/by-name/%s")

--- a/tests/LeagueAPI/Endpoint/SummonerEndpointTest.php
+++ b/tests/LeagueAPI/Endpoint/SummonerEndpointTest.php
@@ -97,36 +97,36 @@ class SummonerEndpointTest extends RiotAPITestCase
 	}
 
 	public function emptySummonerNameProvider(): array
-    {
-        return [
-            'Empty string' => [
-                'summonerName' => ''
-            ],
-            'String containing one space' => [
-                'summonerName' => ' '
-            ],
-            'String containing two space' => [
-                'summonerName' => '  '
-            ],
-            'String containing multiple spaces' => [
-                'summonerName' => '       '
-            ],
-        ];
-    }
+	{
+		return [
+			'Empty string' => [
+				'summonerName' => ''
+			],
+			'String containing one space' => [
+				'summonerName' => ' '
+			],
+			'String containing two space' => [
+				'summonerName' => '  '
+			],
+			'String containing multiple spaces' => [
+				'summonerName' => '       '
+			],
+		];
+	}
 
-    /**
-     * @depends testInit
-     * @dataProvider emptySummonerNameProvider
-     *
-     * @param LeagueAPI $api
-     */
+	/**
+	 * @depends testInit
+	 * @dataProvider emptySummonerNameProvider
+	 *
+	 * @param LeagueAPI $api
+	 */
 	public function testGetSummonerByNameThrowsAnExceptionInCaseNoNameIsSubmitted(string $summonerName, LeagueAPI $api)
-    {
-        $this->expectException(RequestParameterException::class);
-        $this->expectExceptionMessage('Provided summoner name must not be empty');
+	{
+		$this->expectException(RequestParameterException::class);
+		$this->expectExceptionMessage('Provided summoner name must not be empty');
 
-        $api->getSummonerByName($summonerName);
-    }
+		$api->getSummonerByName($summonerName);
+	}
 
 	/**
 	 * @depends testInit

--- a/tests/LeagueAPI/Endpoint/SummonerEndpointTest.php
+++ b/tests/LeagueAPI/Endpoint/SummonerEndpointTest.php
@@ -96,6 +96,38 @@ class SummonerEndpointTest extends RiotAPITestCase
 		$this->assertInternalType('integer', $result->revisionDate);
 	}
 
+	public function emptySummonerNameProvider(): array
+    {
+        return [
+            'Empty string' => [
+                'summonerName' => ''
+            ],
+            'String containing one space' => [
+                'summonerName' => ' '
+            ],
+            'String containing two space' => [
+                'summonerName' => '  '
+            ],
+            'String containing multiple spaces' => [
+                'summonerName' => '       '
+            ],
+        ];
+    }
+
+    /**
+     * @depends testInit
+     * @dataProvider emptySummonerNameProvider
+     *
+     * @param LeagueAPI $api
+     */
+	public function testGetSummonerByNameThrowsAnExceptionInCaseNoNameIsSubmitted(string $summonerName, LeagueAPI $api)
+    {
+        $this->expectException(RequestParameterException::class);
+        $this->expectExceptionMessage('Provided summoner name must not be empty');
+
+        $api->getSummonerByName($summonerName);
+    }
+
 	/**
 	 * @depends testInit
 	 *


### PR DESCRIPTION
Currently when the summoner name is empty, the error you get says nothing about the actual issue.

```php
$api->getSummonerByName('');

// Will throw an RiotAPI\LeagueAPI\Exceptions\ForbiddenException with the message "LeagueAPI: Forbidden. Forbidden"
```

After this change it is clear that the user has done something wrong:

```php
$api->getSummonerByName('');

// Will throw an \RiotAPI\LeagueAPI\Exceptions\RequestParameterException with the message "Provided summoner name must not be empty"
```

Such checks are already made in several other methods for the tournerment API, like `\RiotAPI\LeagueAPI\LeagueAPI::createTournament`.

If this check was there before I would've saved a bit of time debugging. I actually thought my API token was wrong or invalid the whole time 🙈.